### PR TITLE
Pull Request: Update Formulas to Support Services Instead of plist_options

### DIFF
--- a/Formula/vsh-elasticsearch1.rb
+++ b/Formula/vsh-elasticsearch1.rb
@@ -80,36 +80,12 @@ class VshElasticsearch1 < Formula
     EOS
   end
 
-  plist_options :manual => "vsh-elasticsearch1"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_libexec}/bin/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do 
+    run opt_libexec/"bin/elasticsearch"
+    keep_alive false
+    working_dir var
+    log_path var/"log/elasticsearch.log"
+    error_log_path var/"log/elasticsearch.log"
   end
 
   test do

--- a/Formula/vsh-elasticsearch2.rb
+++ b/Formula/vsh-elasticsearch2.rb
@@ -85,36 +85,12 @@ class VshElasticsearch2 < Formula
     EOS
   end
 
-  plist_options :manual => "vsh-elasticsearch2"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_libexec}/bin/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do 
+    run opt_libexec/"bin/elasticsearch"
+    keep_alive false
+    working_dir var
+    log_path var/"log/elasticsearch.log"
+    error_log_path var/"log/elasticsearch.log"
   end
 
   test do

--- a/Formula/vsh-elasticsearch5.rb
+++ b/Formula/vsh-elasticsearch5.rb
@@ -94,36 +94,12 @@ class VshElasticsearch5 < Formula
     EOS
   end
 
-  plist_options :manual => "vsh-elasticsearch5"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_libexec}/bin/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do 
+    run opt_libexec/"bin/elasticsearch"
+    keep_alive false
+    working_dir var
+    log_path var/"log/elasticsearch.log"
+    error_log_path var/"log/elasticsearch.log"
   end
 
   test do

--- a/Formula/vsh-elasticsearch6.rb
+++ b/Formula/vsh-elasticsearch6.rb
@@ -90,36 +90,12 @@ class VshElasticsearch6 < Formula
     EOS
   end
 
-  plist_options :manual => "vsh-elasticsearch6"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_libexec}/bin/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do 
+    run opt_libexec/"bin/elasticsearch"
+    keep_alive false
+    working_dir var
+    log_path var/"log/elasticsearch.log"
+    error_log_path var/"log/elasticsearch.log"
   end
 
   test do

--- a/Formula/vsh-elasticsearch7.rb
+++ b/Formula/vsh-elasticsearch7.rb
@@ -101,36 +101,12 @@ class VshElasticsearch7 < Formula
     EOS
   end
 
-  plist_options :manual => "vsh-elasticsearch7"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_libexec}/bin/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do 
+    run opt_libexec/"bin/elasticsearch"
+    keep_alive false
+    working_dir var
+    log_path var/"log/elasticsearch.log"
+    error_log_path var/"log/elasticsearch.log"
   end
 
   test do

--- a/Formula/vsh-elasticsearch8.rb
+++ b/Formula/vsh-elasticsearch8.rb
@@ -100,36 +100,12 @@ class VshElasticsearch8 < Formula
     EOS
   end
 
-  plist_options :manual => "vsh-elasticsearch8"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_libexec}/bin/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do 
+    run opt_libexec/"bin/elasticsearch"
+    keep_alive false
+    working_dir var
+    log_path var/"log/elasticsearch.log"
+    error_log_path var/"log/elasticsearch.log"
   end
 
   test do

--- a/Formula/vsh-mariadb104.rb
+++ b/Formula/vsh-mariadb104.rb
@@ -188,31 +188,10 @@ class VshMariadb104 < Formula
     s
   end
 
-  plist_options :manual => "vsh-mariadb104"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{libexec}/bin/mysqld_safe</string>
-          <string>--defaults-file=#{etc}/#{name}/my.cnf</string>
-          <string>--datadir=#{datadir}</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{datadir}</string>
-      </dict>
-      </plist>
-    EOS
+  service do 
+    run [libexec/"bin/mysqld_safe", "--defaults-file=#{etc}/vsh-mariadb104/my.cnf", "--datadir=#{var}/vsh-mariadb104"]
+    keep_alive true
+    working_dir var/"vsh-mariadb104"
   end
 
   test do

--- a/Formula/vsh-mariadb106.rb
+++ b/Formula/vsh-mariadb106.rb
@@ -191,31 +191,10 @@ class VshMariadb106 < Formula
     s
   end
 
-  plist_options :manual => "vsh-mariadb106"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{libexec}/bin/mysqld_safe</string>
-          <string>--defaults-file=#{etc}/#{name}/my.cnf</string>
-          <string>--datadir=#{datadir}</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{datadir}</string>
-      </dict>
-      </plist>
-    EOS
+  service do 
+    run [libexec/"bin/mysqld_safe", "--defaults-file=#{etc}/vsh-mariadb106/my.cnf", "--datadir=#{var}/vsh-mariadb106"]
+    keep_alive true
+    working_dir var/"vsh-mariadb106"
   end
 
   test do

--- a/Formula/vsh-mysql57.rb
+++ b/Formula/vsh-mysql57.rb
@@ -171,31 +171,10 @@ class VshMysql57 < Formula
     s
   end
 
-  plist_options :manual => "vsh-mysql57"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{libexec}/bin/mysqld_safe</string>
-          <string>--defaults-file=#{etc}/#{name}/my.cnf</string>
-          <string>--datadir=#{datadir}</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{datadir}</string>
-      </dict>
-      </plist>
-    EOS
+  service do 
+    run [libexec/"bin/mysqld_safe", "--defaults-file=#{etc}/vsh-mysql57/my.cnf", "--datadir=#{var}/vsh-mysql57"]
+    keep_alive true
+    working_dir var/"vsh-mysql57"
   end
 
   test do

--- a/Formula/vsh-mysql80.rb
+++ b/Formula/vsh-mysql80.rb
@@ -183,31 +183,10 @@ class VshMysql80 < Formula
     s
   end
 
-  plist_options :manual => "vsh-mysql80"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{libexec}/bin/mysqld_safe</string>
-          <string>--defaults-file=#{etc}/#{name}/my.cnf</string>
-          <string>--datadir=#{datadir}</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{datadir}</string>
-      </dict>
-      </plist>
-    EOS
+  service do 
+    run [libexec/"bin/mysqld_safe", "--defaults-file=#{etc}/vsh-mysql80/my.cnf", "--datadir=#{var}/vsh-mysql80"]
+    keep_alive true
+    working_dir var/"vsh-mysql80"
   end
 
   test do

--- a/Formula/vsh-opensearch1.rb
+++ b/Formula/vsh-opensearch1.rb
@@ -103,36 +103,12 @@ class VshOpensearch1 < Formula
     EOS
   end
 
-  plist_options :manual => "vsh-opensearch1"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_libexec}/bin/opensearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}/opensearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}/opensearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do 
+    run opt_libexec/"bin/opensearch"
+    keep_alive false
+    working_dir var
+    log_path var/"log/opensearch.log"
+    error_log_path var/"log/opensearch.log"
   end
 
   test do

--- a/Formula/vsh-opensearch2.rb
+++ b/Formula/vsh-opensearch2.rb
@@ -103,36 +103,12 @@ class VshOpensearch2 < Formula
     EOS
   end
 
-  plist_options :manual => "vsh-opensearch2"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_libexec}/bin/opensearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}/opensearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}/opensearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do 
+    run opt_libexec/"bin/opensearch"
+    keep_alive false
+    working_dir var
+    log_path var/"log/opensearch.log"
+    error_log_path var/"log/opensearch.log"
   end
 
   test do

--- a/Formula/vsh-php56.rb
+++ b/Formula/vsh-php56.rb
@@ -323,31 +323,14 @@ class VshPhp56 < Formula
     File.basename(extension_dir)
   end
 
-  plist_options :manual => "php-fpm5.6"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php56.log"
   end
 
   test do

--- a/Formula/vsh-php70.rb
+++ b/Formula/vsh-php70.rb
@@ -298,31 +298,14 @@ class VshPhp70 < Formula
     File.basename(extension_dir)
   end
 
-  plist_options :manual => "php-fpm7.0"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php70.log"
   end
 
   test do

--- a/Formula/vsh-php71.rb
+++ b/Formula/vsh-php71.rb
@@ -303,31 +303,14 @@ class VshPhp71 < Formula
     File.basename(extension_dir)
   end
 
-  plist_options :manual => "php-fpm7.1"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php71.log"
   end
 
   test do

--- a/Formula/vsh-php72.rb
+++ b/Formula/vsh-php72.rb
@@ -306,31 +306,14 @@ class VshPhp72 < Formula
     File.basename(extension_dir)
   end
 
-  plist_options :manual => "php-fpm7.2"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php72.log"
   end
 
   test do

--- a/Formula/vsh-php73.rb
+++ b/Formula/vsh-php73.rb
@@ -316,31 +316,14 @@ class VshPhp73 < Formula
     Utils.popen_read("#{bin}/php-config#{bin_suffix} --extension-dir").chomp
   end
 
-  plist_options :manual => "php-fpm7.3"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php73.log"
   end
 
   test do

--- a/Formula/vsh-php74.rb
+++ b/Formula/vsh-php74.rb
@@ -320,31 +320,14 @@ class VshPhp74 < Formula
     Utils.popen_read("#{bin}/php-config#{bin_suffix} --extension-dir").chomp
   end
 
-  plist_options :manual => "php-fpm7.4"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php74.log"
   end
 
   test do

--- a/Formula/vsh-php80.rb
+++ b/Formula/vsh-php80.rb
@@ -302,31 +302,14 @@ class VshPhp80 < Formula
     File.basename(extension_dir)
   end
 
-  plist_options :manual => "php-fpm8.0"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php80.log"
   end
 
   test do

--- a/Formula/vsh-php81.rb
+++ b/Formula/vsh-php81.rb
@@ -304,31 +304,14 @@ class VshPhp81 < Formula
     File.basename(extension_dir)
   end
 
-  plist_options :manual => "php-fpm8.1"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php81.log"
   end
 
   test do

--- a/Formula/vsh-php82.rb
+++ b/Formula/vsh-php82.rb
@@ -297,31 +297,14 @@ class VshPhp82 < Formula
     File.basename(extension_dir)
   end
 
-  plist_options :manual => "php-fpm8.2"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_sbin}/php-fpm#{bin_suffix}</string>
-          <string>--nodaemonize</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do 
+    php_version = @formula.version.to_s.split(".")[0..1].join(".")
+    bin_suffix = php_version
+  
+    run ["#{opt_sbin}/php-fpm#{bin_suffix}", "--nodaemonize"]
+    keep_alive true
+    working_dir var
+    error_log_path var/"log/vsh-php82.log"
   end
 
   test do


### PR DESCRIPTION
### Description
Currently, some services are still using `plist_options`, which causes failures because Homebrew has disabled the `plist_options` function.
This pull request updates the formulas to use a service instead of `plist_options`.

For instance, when attempting to start the Elasticsearch7 service via `valet.sh service start elasticsearch7`, it fails with the following output:
```
fatal: [local]: FAILED! => {"changed": true, "cmd": "arch --x86_64 /usr/local/bin/brew services start vsh-elasticsearch7", "delta": "0:00:02.314357", "end": "2023-07-24 08:19:42.047784", "msg": "non-zero return code", "rc": 1, "start": "2023-07-24 08:19:39.733427", "stderr": "Error: vsh-elasticsearch7: Calling plist_options is disabled! Use service.require_root instead.\nPlease report this issue to the valet-sh/core tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:\n /usr/local/Homebrew/Library/Taps/valet-sh/homebrew-core/Formula/vsh-elasticsearch7.rb:104", "stderr_lines": ["Error: vsh-elasticsearch7: Calling plist_options is disabled! Use service.require_root instead.", "Please report this issue to the valet-sh/core tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:", " /usr/local/Homebrew/Library/Taps/valet-sh/homebrew-core/Formula/vsh-elasticsearch7.rb:104"], "stdout": "", "stdout_lines": []}
```
### Changes Made
All formulas that were still using `plist_options` have been updated to use the appropriate service. However, there is room for further improvement, such as eliminating the need to add the `vsh-SERVICENAME` and resolving `#{name}` properly (currently not working). I plan to investigate this further, but with this pull request, you can restart the services as before. Even after a complete reinstall, the services are correctly installed with the defined options. I have compared the services before and after the changes, and they remain the same with the options properly set.